### PR TITLE
Feature/rjm ldap for api

### DIFF
--- a/airflow/api/auth/backend/ldap_auth.py
+++ b/airflow/api/auth/backend/ldap_auth.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from functools import wraps
+
+from airflow import configuration as conf
+from airflow.contrib.auth.backends.ldap_auth import LdapUser
+
+from flask import Response
+from flask import _request_ctx_stack as stack
+from flask import make_response
+from flask import request
+from flask import g
+
+_log = logging.getLogger(__name__)
+
+
+def init_app(app):
+    pass
+
+
+def _forbidden():
+    return Response("Forbidden", 403)
+
+
+def requires_authentication(function):
+    @wraps(function)
+    def decorated(*args, **kwargs):
+        header = request.headers.get("Authorization")
+        if header:
+            _log.debug(header)
+            try:
+                LdapUser.try_login(header.username, header.password)
+                response = function(*args, **kwargs)
+                response = make_response(response)
+                return response
+            except Exception as exception:
+                _log.info("API login failure: {}".format(exception))
+        return _forbidden()
+    return decorated

--- a/airflow/api/auth/backend/ldap_auth.py
+++ b/airflow/api/auth/backend/ldap_auth.py
@@ -35,6 +35,14 @@ def _forbidden():
     return Response("Forbidden", 403)
 
 
+def _unauthorized():
+    """
+    Indicate that authorization is required
+    :return:
+    """
+    return Response("Unauthorized", 401)
+
+
 def requires_authentication(function):
     @wraps(function)
     def decorated(*args, **kwargs):
@@ -48,5 +56,6 @@ def requires_authentication(function):
                 return response
             except Exception as exception:
                 _log.info("API login failure: {}".format(exception))
-        return _forbidden()
+            return _forbidden()
+        return _unauthorized()
     return decorated

--- a/airflow/api/auth/backend/ldap_auth.py
+++ b/airflow/api/auth/backend/ldap_auth.py
@@ -15,16 +15,16 @@
 import logging
 from functools import wraps
 
-from airflow import configuration as conf
-from airflow.contrib.auth.backends.ldap_auth import LdapUser
-
 from flask import Response
-from flask import _request_ctx_stack as stack
 from flask import make_response
 from flask import request
-from flask import g
+
+from airflow.contrib.auth.backends.ldap_auth import LdapUser
 
 _log = logging.getLogger(__name__)
+
+client_auth = None
+requires_authentication = True
 
 
 def init_app(app):


### PR DESCRIPTION
Added new Auth method for the API.

This takes a username and password sent using the Basic Authorization protocol and checks them against an LDAP system. This pulls from the LDAP auth set up for the WebUI and allows the same users access to the API.

