### PR TITLE
Fix http/https issues behind a proxy & prevent creation of extra log files

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -27,6 +27,7 @@ from airflow import models
 from airflow.settings import Session
 
 from airflow.www.blueprints import routes
+from airflow.www.reverse_proxied import ReverseProxied
 from airflow import jobs
 from airflow import settings
 from airflow import configuration
@@ -35,6 +36,7 @@ _log = logging.getLogger(__name__)
 
 def create_app(config=None, testing=False):
     app = Flask(__name__)
+    app.wsgi_app = ReverseProxied(app.wsgi_app)
     app.secret_key = configuration.get('webserver', 'SECRET_KEY')
     app.config['LOGIN_DISABLED'] = not configuration.getboolean('webserver', 'AUTHENTICATE')
 

--- a/airflow/www/reverse_proxied.py
+++ b/airflow/www/reverse_proxied.py
@@ -1,0 +1,29 @@
+
+
+class ReverseProxied(object):
+    '''Wrap the application in this middleware and configure the
+    front-end server to add these headers, to let you quietly bind
+    this to a URL other than / and to an HTTP scheme that is
+    different than what is used locally.
+
+    In nginx:
+    location /myprefix {
+        proxy_pass http://192.168.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Script-Name /myprefix;
+        }
+
+    Modified from snippet here: http://flask.pocoo.org/snippets/35/
+
+    :param app: the WSGI application
+    '''
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        scheme = environ.get('HTTP_X_FORWARDED_PROTO', '')
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+        return self.app(environ, start_response)


### PR DESCRIPTION
airflow/www/app.py and airflow/www/reverse_proxy.py add a middleware class that detects if the incoming request was actually https before it hit the proxy and cause redirects to target https instead of http. This allows the UI to work properly behind a proxy without needing https:// adding into the url manually after certain operations.

The other changes here takes out the functionality which logs the output of the dag parsing process in the scheduler that create a whole load of extra log files in the airflow home folder instead of the airflow log folder. Any logging here is already being caught appropriately anyway and we want to get rid of these logs as there's no nice way of automatically trimming them with logrotate or the like.